### PR TITLE
Fix PS1

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -7,23 +7,23 @@ say_progress() {
 set -e
 
 command -v brew >/dev/null 2>&1 || {
-  say_progress "Installing Homebrew"
+  say_progress 'Installing Homebrew'
   /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 }
 
-say_progress "Bundling Brewfile"
+say_progress 'Bundling Brewfile'
 brew update
 brew bundle
 brew cleanup -s
 
-say_progress "Stowing stowage"
+say_progress 'Stowing stowage'
 stow --restow --target="$HOME" --verbose stowage
 
-say_progress "Configuring macOS"
+say_progress 'Configuring macOS'
 source bin/macos
 
-say_progress "Plugging Vim"
+say_progress 'Plugging Vim'
 vim -c PlugInstall -c quitall
 
-say_progress "Importing terminal profile"
-open "Solarized Dark.terminal"
+say_progress 'Importing terminal profile'
+open 'Solarized Dark.terminal'

--- a/stowage/.bash_profile
+++ b/stowage/.bash_profile
@@ -2,8 +2,8 @@
 export EDITOR=vi
 
 # Aliases
-alias gg="git grep -I --break --heading --show-function --untracked"
-alias ll="ls -alFG"
+alias gg='git grep -I --break --heading --show-function --untracked'
+alias ll='ls -alFG'
 
 # rbenv
 eval "$(rbenv init -)"
@@ -19,4 +19,4 @@ source "$(brew --prefix)/etc/bash_completion"
 
 # PS1
 GIT_PS1_SHOWDIRTYSTATE=true
-export PS1="\W[$(rbenv version-name)]$(__git_ps1 "(%s)")$ "
+export PS1='\W[$(rbenv version-name)]$(__git_ps1 "(%s)")$ '

--- a/stowage/.tmux.conf
+++ b/stowage/.tmux.conf
@@ -1,8 +1,8 @@
 # Support `open` command on macOS
-set -g default-command "reattach-to-user-namespace -l /bin/bash"
+set -g default-command 'reattach-to-user-namespace -l /bin/bash'
 
 # Improve colors
-set-option -g default-terminal "screen-256color"
+set-option -g default-terminal 'screen-256color'
 
 # Increase scrollback lines
 set -g history-limit 10000
@@ -18,8 +18,8 @@ bind-key C-g last-window
 set-window-option -g mode-keys vi
 
 # Clean up status bar
-set-option -g status-left ""
-set-option -g status-right ""
+set-option -g status-left ''
+set-option -g status-right ''
 
 # Use Solarized Dark theme
 set-option -g display-panes-active-colour blue


### PR DESCRIPTION
I recently switched my `PS1` to double quotes, which caused it to be
expanded when the prompt is defined rather than when it's displayed.
That prevented functionality like `__git_ps1` from working as expected.
This reverses that change and updates the project to consistently use
single quotes where possible.

Related:

https://www.gnu.org/software/bash/manual/html_node/Quoting.html
